### PR TITLE
Produce coverage report only for hangman.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install coverage
   - pip install python-coveralls
 
-script: coverage run setup.py test
+script: coverage run --source=hangman.py setup.py test
 
 after_success:
   - coveralls


### PR DESCRIPTION
If not coveralls tries to report coverage for other testing modules as well.