### PR TITLE
Edit play_again() to completely verify input

### DIFF
--- a/gallows.py
+++ b/gallows.py
@@ -160,7 +160,7 @@ class Hangman:
             xprint('You have run out of guesses!')
             xprint('After {0} missed guesses and {1} correct guesses, '
                    'the word was "{2}"'.format(missed, correct, word))
-            
+
             return True
 
         return False
@@ -188,7 +188,7 @@ def play_again():
     """Returns True if the player wants to play again, False otherwise."""
 
     xprint('Do you want to play again? (yes or no)')
-    return input().lower().startswith('y')
+    return input().lower() is 'yes'
 
 
 def main():

--- a/gallows.py
+++ b/gallows.py
@@ -188,7 +188,7 @@ def play_again():
     """Returns True if the player wants to play again, False otherwise."""
 
     xprint('Do you want to play again? (yes or no)')
-    return input().lower() is 'yes'
+    return input().lower() == 'yes'
 
 
 def main():

--- a/test.py
+++ b/test.py
@@ -46,8 +46,9 @@ class HangmanTestCase(unittest.TestCase):
 
     def test_two_game(self):
         """Test two winning game plays."""
+        from itertools import chain
         self.choice.side_effect = ["ant", "baboon"]
-        self.input.side_effect = list("ant" "y" "babon" "n")
+        self.input.side_effect = chain(list("ant"), ["yes"], list("babon"), ["no"])
 
         gallows.main()
 


### PR DESCRIPTION
The present play_again() function has the following statement - 

```python
    return input().lower().startswith('y')
```

This leads to erroneous inputs like 'yno' being accepted to continue playing. 

Verifying the entire message will ensure that only the message 'yes' will allow the player to continue. 