### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Gallows
 .. image:: https://img.shields.io/coveralls/Chennaipy/hangman.svg?style=flat
   :target: https://coveralls.io/r/Chennaipy/hangman
 
-.. image:: https://pypip.in/version/gallows/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/gallows.svg?style=flat
   :target: https://pypi.python.org/pypi/gallows/
   :alt: Latest Version
 
@@ -15,7 +15,7 @@ Gallows
   :target: https://readthedocs.org/projects/gallows/?badge=latest
      :alt: Documentation Status
 
-.. image:: https://pypip.in/py_versions/gallows/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/gallows.svg?style=flat
     :target: https://pypi.python.org/pypi/gallows/
     :alt: Supported Python versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20gallows))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `gallows`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.